### PR TITLE
Fix call to set_confirmed_msg_retries

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -110,8 +110,8 @@ int main (void)
     lorawan.add_app_callbacks(&callbacks);
 
     // Set number of retries in case of CONFIRMED messages
-    if (lorawan.set_confirmed_msg_retries(CONFIRMED_MSG_RETRY_COUNTER
-                                          != LORA_MAC_STATUS_OK)) {
+    if (lorawan.set_confirmed_msg_retries(CONFIRMED_MSG_RETRY_COUNTER)
+                                          != LORA_MAC_STATUS_OK) {
         printf("\r\n set_confirmed_msg_retries failed! \r\n\r\n");
         return -1;
     }


### PR DESCRIPTION
One parenthesis was in incorrect place resulted in set_confirmed_msg_retries
to be always called with value 1.