### PR TITLE
Add stdio.h for printf

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <stdio.h>
 #include "lorawan/LoRaWANInterface.h"
 #include "lorawan/system/lorawan_data_structures.h"
 #include "events/EventQueue.h"


### PR DESCRIPTION
After changing includes in headers, our main.cpp now requires #include <stdio.h> for printf calls.