### PR TITLE
Trace helper modification

### DIFF
--- a/trace_helper.cpp
+++ b/trace_helper.cpp
@@ -15,8 +15,12 @@
  * limitations under the License.
  */
 
-#include "Serial.h"
-#include "rtos/Mutex.h"
+#include "drivers/Serial.h"
+
+/**
+ * Serial object for console tracing
+ */
+mbed::Serial pc(USBTX, USBRX, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
 
 /**
  * If we have tracing library available, we can see traces from within the
@@ -24,71 +28,63 @@
  * from the mbed_app.json to save RAM.
  */
 #if defined(FEATURE_COMMON_PAL)
- #include "mbed_trace.h"
+
+    #include "rtos/Mutex.h"
+    #include "mbed_trace.h"
+
+    /**
+     * Local mutex object for synchronization
+     */
+    static rtos::Mutex mutex;
+
+    static void serial_lock();
+    static void serial_unlock();
+    static void trace_printer(const char* str);
+
+    /**
+     * Sets up trace for the application
+     * Wouldn't do anything if the FEATURE_COMMON_PAL is not added
+     * or if the trace is disabled using mbed_app.json
+     */
+    void setup_trace()
+    {
+        // setting up Mbed trace.
+        mbed_trace_mutex_wait_function_set(serial_lock);
+        mbed_trace_mutex_release_function_set(serial_unlock);
+        mbed_trace_init();
+        mbed_trace_print_function_set(trace_printer);
+    }
+
+    /**
+     * Lock provided for serial printing used by trace library
+     */
+    static void serial_lock()
+    {
+        mutex.lock();
+    }
+
+    /**
+     * Releasing lock provided for serial printing used by trace library
+     */
+    static void serial_unlock()
+    {
+        mutex.unlock();
+    }
+
+    /**
+     * Prints the Mbed trace, used by trace library.
+     * Not intended for local use.
+     */
+    static void trace_printer(const char* str)
+    {
+        printf("%s\r\n", str);
+    }
+
 #else
-//dummies if feature common pal is not added
- #define mbed_trace_mutex_wait_function_set(...) (void(0))
- #define mbed_trace_mutex_release_function_set(...) (void(0))
- #define mbed_trace_init(...) (void(0))
- #define mbed_trace_print_function_set(...) (void(0))
-#endif //defined(FEATURE_COMMON_PAL)
 
-using namespace mbed;
-using namespace rtos;
+    void setup_trace()
+    {
+    }
 
-/**
- * Serial object for console tracing
- */
-static Serial pc(USBTX, USBRX);
-
-/**
- * Local mutex object for synchronization
- */
-static Mutex mutex;
-
-static void serial_lock();
-static void serial_unlock();
-static void trace_printer(const char* str);
-
-/**
- * Sets up trace for the application
- * Wouldn't do anything if the FEATURE_COMMON_PAL is not added
- * or if the trace is disabled using mbed_app.json
- */
-void setup_trace()
-{
-    // setting up baudrate for console printer
-    pc.baud(115200);
-    // setting up Mbed trace. Doesn't do anything if
-    // FEATURE_COMMON_PAL is not available
-    mbed_trace_mutex_wait_function_set(serial_lock);
-    mbed_trace_mutex_release_function_set(serial_unlock);
-    mbed_trace_init();
-    mbed_trace_print_function_set(trace_printer);
-}
-
-/**
- * Lock provided for serial printing used by trace library
- */
-static void serial_lock()
-{
-    mutex.lock();
-}
-
-/**
- * Releasing lock provided for serial printing used by trace library
- */
-static void serial_unlock()
-{
-    mutex.unlock();
-}
-
-/**
- * Prints the Mbed trace, used by trace library.
- * Not intended for local use.
- */
-static void trace_printer(const char* str)
-{
-    printf("%s\r\n", str);
-}
+#endif
 


### PR DESCRIPTION
Trace helper was pulling in rtos bits which we may hamper
if we were to drop rtos for memory constrained platforms.