### PR TITLE
Use Serial object for trace prints

### DIFF
--- a/trace_helper.cpp
+++ b/trace_helper.cpp
@@ -77,7 +77,7 @@ mbed::Serial pc(USBTX, USBRX, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
      */
     static void trace_printer(const char* str)
     {
-        printf("%s\r\n", str);
+        pc.printf("%s\r\n", str);
     }
 
 #else


### PR DESCRIPTION
Use Serial object instead of stdout for trace prints. This is also
logical as we construct Serial object in the beginning of the source file.
Also this enables easier tracing with new targets where stdout might not
work at the beginning.