### PR TITLE
Reduce example application memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ To enable Mbed trace, add to your `mbed_app.json` the following fields:
             }
      }
 ```
-The trace is disabled by default to save RAM.
+The trace is disabled by default to save RAM and reduce main stack usage (see chapter Memory optimization).
+
+**Please note that some targets with small RAM size (e.g. DISCO_L072CZ_LRWAN1 and MTB_MURATA_ABZ) mbed traces cannot be enabled without increasing the default** `"main_stack_size": 1024`**.**
 
 ## [Optional] Memory optimization 
 

--- a/main.cpp
+++ b/main.cpp
@@ -31,8 +31,11 @@
 
 using namespace events;
 
-uint8_t tx_buffer[LORAMAC_PHY_MAXPAYLOAD];
-uint8_t rx_buffer[LORAMAC_PHY_MAXPAYLOAD];
+// Max payload size can be LORAMAC_PHY_MAXPAYLOAD.
+// This example only communicates with much shorter messages (<30 bytes).
+// If longer messages are used, these buffers must be changed accordingly.
+uint8_t tx_buffer[30];
+uint8_t rx_buffer[30];
 
 /*
  * Sets up an application dependent transmission timer in ms. Used only when Duty Cycling is off for testing
@@ -41,10 +44,10 @@ uint8_t rx_buffer[LORAMAC_PHY_MAXPAYLOAD];
 
 /**
  * Maximum number of events for the event queue.
- * 16 is the safe number for the stack events, however, if application
+ * 10 is the safe number for the stack events, however, if application
  * also uses the queue for whatever purposes, this number should be increased.
  */
-#define MAX_NUMBER_OF_EVENTS            16
+#define MAX_NUMBER_OF_EVENTS            10
 
 /**
  * Maximum number of retries for CONFIRMED messages before giving up
@@ -179,7 +182,7 @@ static void send_message()
     }
 
     printf("\r\n %d bytes scheduled for transmission \r\n", retcode);
-    memset(tx_buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
+    memset(tx_buffer, 0, sizeof(tx_buffer));
 }
 
 /**
@@ -189,7 +192,7 @@ static void receive_message()
 {
     int16_t retcode;
     retcode = lorawan.receive(MBED_CONF_LORA_APP_PORT, rx_buffer,
-                              LORAMAC_PHY_MAXPAYLOAD,
+                              sizeof(rx_buffer),
                               MSG_CONFIRMED_FLAG|MSG_UNCONFIRMED_FLAG);
 
     if (retcode < 0) {
@@ -205,7 +208,7 @@ static void receive_message()
 
     printf("\r\n Data Length: %d\r\n", retcode);
 
-    memset(rx_buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
+    memset(rx_buffer, 0, sizeof(rx_buffer));
 }
 
 /**

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -64,7 +64,7 @@
         },
 
         "DISCO_L072CZ_LRWAN1": {
-            "main_stack_size":      3072,
+            "main_stack_size":      1024,
             "lorawan-enabled":      true,
 
             "lora-radio":          "SX1276",
@@ -89,6 +89,7 @@
         },
 
         "MTB_MURATA_ABZ": {
+            "main_stack_size":      1024,
             "lorawan-enabled":      true,
 
             "lora-radio":          "SX1276",


### PR DESCRIPTION
Fix for issue #58.

Our currently supported targets DISCO_L072CZ_LRWAN1 and MTB_MURATA_ABZ
only have 20kB of RAM which requires some memory usage optimizations
to LoRa example application especially when compiled with GCC compiler.

This commit reduces application tx and rx buffers to 30 bytes (instead of
255) as application only sends short messages.

Also main thread stack size is reduced to 1024 bytes for these two targets.
NOTE! Due to small stack size, mbed traces cannot be enabled for these targets!
