### PR TITLE
Create lora objects into heap

### DIFF
--- a/lora_radio_helper.h
+++ b/lora_radio_helper.h
@@ -30,51 +30,66 @@
 #define SX1272   0xFF
 #define SX1276   0xEE
 
+static LoRaRadio* radio;
+
+void create_radio()
+{
 #if (MBED_CONF_APP_LORA_RADIO == SX1272)
-
-    SX1272_LoRaRadio radio(MBED_CONF_APP_LORA_SPI_MOSI,
-                           MBED_CONF_APP_LORA_SPI_MISO,
-                           MBED_CONF_APP_LORA_SPI_SCLK,
-                           MBED_CONF_APP_LORA_CS,
-                           MBED_CONF_APP_LORA_RESET,
-                           MBED_CONF_APP_LORA_DIO0,
-                           MBED_CONF_APP_LORA_DIO1,
-                           MBED_CONF_APP_LORA_DIO2,
-                           MBED_CONF_APP_LORA_DIO3,
-                           MBED_CONF_APP_LORA_DIO4,
-                           MBED_CONF_APP_LORA_DIO5,
-                           MBED_CONF_APP_LORA_RF_SWITCH_CTL1,
-                           MBED_CONF_APP_LORA_RF_SWITCH_CTL2,
-                           MBED_CONF_APP_LORA_TXCTL,
-                           MBED_CONF_APP_LORA_RXCTL,
-                           MBED_CONF_APP_LORA_ANT_SWITCH,
-                           MBED_CONF_APP_LORA_PWR_AMP_CTL,
-                           MBED_CONF_APP_LORA_TCXO);
-
+    radio = new SX1272_LoRaRadio(MBED_CONF_APP_LORA_SPI_MOSI,
+                                 MBED_CONF_APP_LORA_SPI_MISO,
+                                 MBED_CONF_APP_LORA_SPI_SCLK,
+                                 MBED_CONF_APP_LORA_CS,
+                                 MBED_CONF_APP_LORA_RESET,
+                                 MBED_CONF_APP_LORA_DIO0,
+                                 MBED_CONF_APP_LORA_DIO1,
+                                 MBED_CONF_APP_LORA_DIO2,
+                                 MBED_CONF_APP_LORA_DIO3,
+                                 MBED_CONF_APP_LORA_DIO4,
+                                 MBED_CONF_APP_LORA_DIO5,
+                                 MBED_CONF_APP_LORA_RF_SWITCH_CTL1,
+                                 MBED_CONF_APP_LORA_RF_SWITCH_CTL2,
+                                 MBED_CONF_APP_LORA_TXCTL,
+                                 MBED_CONF_APP_LORA_RXCTL,
+                                 MBED_CONF_APP_LORA_ANT_SWITCH,
+                                 MBED_CONF_APP_LORA_PWR_AMP_CTL,
+                                 MBED_CONF_APP_LORA_TCXO);
 #elif (MBED_CONF_APP_LORA_RADIO == SX1276)
-
-    SX1276_LoRaRadio radio(MBED_CONF_APP_LORA_SPI_MOSI,
-                           MBED_CONF_APP_LORA_SPI_MISO,
-                           MBED_CONF_APP_LORA_SPI_SCLK,
-                           MBED_CONF_APP_LORA_CS,
-                           MBED_CONF_APP_LORA_RESET,
-                           MBED_CONF_APP_LORA_DIO0,
-                           MBED_CONF_APP_LORA_DIO1,
-                           MBED_CONF_APP_LORA_DIO2,
-                           MBED_CONF_APP_LORA_DIO3,
-                           MBED_CONF_APP_LORA_DIO4,
-                           MBED_CONF_APP_LORA_DIO5,
-                           MBED_CONF_APP_LORA_RF_SWITCH_CTL1,
-                           MBED_CONF_APP_LORA_RF_SWITCH_CTL2,
-                           MBED_CONF_APP_LORA_TXCTL,
-                           MBED_CONF_APP_LORA_RXCTL,
-                           MBED_CONF_APP_LORA_ANT_SWITCH,
-                           MBED_CONF_APP_LORA_PWR_AMP_CTL,
-                           MBED_CONF_APP_LORA_TCXO);
-
+    radio = new SX1276_LoRaRadio(MBED_CONF_APP_LORA_SPI_MOSI,
+                                 MBED_CONF_APP_LORA_SPI_MISO,
+                                 MBED_CONF_APP_LORA_SPI_SCLK,
+                                 MBED_CONF_APP_LORA_CS,
+                                 MBED_CONF_APP_LORA_RESET,
+                                 MBED_CONF_APP_LORA_DIO0,
+                                 MBED_CONF_APP_LORA_DIO1,
+                                 MBED_CONF_APP_LORA_DIO2,
+                                 MBED_CONF_APP_LORA_DIO3,
+                                 MBED_CONF_APP_LORA_DIO4,
+                                 MBED_CONF_APP_LORA_DIO5,
+                                 MBED_CONF_APP_LORA_RF_SWITCH_CTL1,
+                                 MBED_CONF_APP_LORA_RF_SWITCH_CTL2,
+                                 MBED_CONF_APP_LORA_TXCTL,
+                                 MBED_CONF_APP_LORA_RXCTL,
+                                 MBED_CONF_APP_LORA_ANT_SWITCH,
+                                 MBED_CONF_APP_LORA_PWR_AMP_CTL,
+                                 MBED_CONF_APP_LORA_TCXO);
 #else
     #error "Unknown LoRa radio specified (SX1272,SX1276 are valid)"
 #endif
+
+    MBED_ASSERT(radio);
+}
+
+void delete_radio()
+{
+#if (MBED_CONF_APP_LORA_RADIO == SX1272)
+    delete (SX1272_LoRaRadio*)radio;
+#elif (MBED_CONF_APP_LORA_RADIO == SX1276)
+    delete (SX1276_LoRaRadio*)radio;
+#else
+    #error "Unknown LoRa radio specified (SX1272,SX1276 are valid)"
+#endif
+    radio = NULL;
+}
 
 #endif //DEVICE_SPI
 

--- a/main.cpp
+++ b/main.cpp
@@ -84,18 +84,26 @@ static void lora_event_handler(lorawan_event_t event);
 /**
  * Constructing Mbed LoRaWANInterface and passing it down the radio object.
  */
-static LoRaWANInterface lorawan(radio);
+static LoRaWANInterface* lorawan;
 
 /**
  * Application specific callbacks
  */
 static lorawan_app_callbacks_t callbacks;
 
+
 /**
  * Entry point for application
  */
 int main (void)
 {
+    // Create radio driver object
+    create_radio();
+
+    // Create LoRaWAN stack object
+    lorawan = new LoRaWANInterface(*radio);
+    MBED_ASSERT(lorawan);
+
     // setup tracing
     setup_trace();
 
@@ -103,7 +111,7 @@ int main (void)
     lorawan_status_t retcode;
 
     // Initialize LoRaWAN stack
-    if (lorawan.initialize(&ev_queue) != LORAWAN_STATUS_OK) {
+    if (lorawan->initialize(&ev_queue) != LORAWAN_STATUS_OK) {
         printf("\r\n LoRa initialization failed! \r\n");
         return -1;
     }
@@ -112,10 +120,10 @@ int main (void)
 
     // prepare application callbacks
     callbacks.events = mbed::callback(lora_event_handler);
-    lorawan.add_app_callbacks(&callbacks);
+    lorawan->add_app_callbacks(&callbacks);
 
     // Set number of retries in case of CONFIRMED messages
-    if (lorawan.set_confirmed_msg_retries(CONFIRMED_MSG_RETRY_COUNTER)
+    if (lorawan->set_confirmed_msg_retries(CONFIRMED_MSG_RETRY_COUNTER)
                                           != LORAWAN_STATUS_OK) {
         printf("\r\n set_confirmed_msg_retries failed! \r\n\r\n");
         return -1;
@@ -125,14 +133,14 @@ int main (void)
            CONFIRMED_MSG_RETRY_COUNTER);
 
     // Enable adaptive data rate
-    if (lorawan.enable_adaptive_datarate() != LORAWAN_STATUS_OK) {
+    if (lorawan->enable_adaptive_datarate() != LORAWAN_STATUS_OK) {
         printf("\r\n enable_adaptive_datarate failed! \r\n");
         return -1;
     }
 
     printf("\r\n Adaptive data  rate (ADR) - Enabled \r\n");
 
-    retcode = lorawan.connect();
+    retcode = lorawan->connect();
 
     if (retcode == LORAWAN_STATUS_OK ||
         retcode == LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
@@ -145,6 +153,12 @@ int main (void)
 
     // make your event queue dispatching events forever
     ev_queue.dispatch_forever();
+
+    // Clean up
+    delete lorawan;
+    lorawan = NULL;
+
+    delete_radio();
 
     return 0;
 }
@@ -172,7 +186,7 @@ static void send_message()
     packet_len = sprintf((char*) tx_buffer, "Dummy Sensor Value is %3.1f",
                     sensor_value);
 
-    retcode = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_buffer, packet_len,
+    retcode = lorawan->send(MBED_CONF_LORA_APP_PORT, tx_buffer, packet_len,
                            MSG_CONFIRMED_FLAG);
 
     if (retcode < 0) {
@@ -191,7 +205,7 @@ static void send_message()
 static void receive_message()
 {
     int16_t retcode;
-    retcode = lorawan.receive(MBED_CONF_LORA_APP_PORT, rx_buffer,
+    retcode = lorawan->receive(MBED_CONF_LORA_APP_PORT, rx_buffer,
                               sizeof(rx_buffer),
                               MSG_CONFIRMED_FLAG|MSG_UNCONFIRMED_FLAG);
 


### PR DESCRIPTION
In order to reduce stack usage, create lora objects into heap.