### PR TITLE
Remove usage of DEVICE_SPI and MBED_CONF_APP_LORAWAN_ENABLED flags

### DIFF
--- a/lora_radio_helper.h
+++ b/lora_radio_helper.h
@@ -20,10 +20,6 @@
 #ifndef APP_LORA_RADIO_HELPER_H_
 #define APP_LORA_RADIO_HELPER_H_
 
-#if MBED_CONF_APP_LORAWAN_ENABLED
-
-#ifdef DEVICE_SPI
-
 #include "SX1272_LoRaRadio.h"
 #include "SX1276_LoRaRadio.h"
 
@@ -75,9 +71,5 @@
 #else
     #error "Unknown LoRa radio specified (SX1272,SX1276 are valid)"
 #endif
-
-#endif //DEVICE_SPI
-
-#endif //MBED_CONF_APP_LORAWAN_ENABLED
 
 #endif /* APP_LORA_RADIO_HELPER_H_ */

--- a/main.cpp
+++ b/main.cpp
@@ -16,10 +16,6 @@
  */
 #include <stdio.h>
 
-#if MBED_CONF_APP_LORAWAN_ENABLED
-
-#ifdef DEVICE_SPI
-
 #include "lorawan/LoRaWANInterface.h"
 #include "lorawan/system/lorawan_data_structures.h"
 #include "events/EventQueue.h"
@@ -262,12 +258,4 @@ static void lora_event_handler(lorawan_event_t event)
     }
 }
 
-#endif //DEVICE_SPI
-
-#else
-int main (void)
-{
-    return 0;
-}
-#endif //MBED_CONF_APP_LORAWAN_ENABLED
 // EOF

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -6,8 +6,6 @@
         },
         "main_stack_size":     { "value": 4096 },
 
-        "lorawan-enabled":     { "value": false},
-
         "lora-spi-mosi":       { "value": "NC" },
         "lora-spi-miso":       { "value": "NC" },
         "lora-spi-sclk":       { "value": "NC" },
@@ -41,8 +39,6 @@
         },
 
         "K64F": {
-            "lorawan-enabled":     true,
-
             "lora-spi-mosi":       "D11",
             "lora-spi-miso":       "D12",
             "lora-spi-sclk":       "D13",
@@ -65,8 +61,6 @@
 
         "DISCO_L072CZ_LRWAN1": {
             "main_stack_size":      1024,
-            "lorawan-enabled":      true,
-
             "lora-radio":          "SX1276",
             "lora-spi-mosi":       "PA_7",
             "lora-spi-miso":       "PA_6",
@@ -90,8 +84,6 @@
 
         "MTB_MURATA_ABZ": {
             "main_stack_size":      1024,
-            "lorawan-enabled":      true,
-
             "lora-radio":          "SX1276",
             "lora-spi-mosi":       "PA_7",
             "lora-spi-miso":       "PA_6",
@@ -114,8 +106,6 @@
         },
 
         "XDOT_L151CC": {
-            "lorawan-enabled":      true,
-
             "lora-radio":           "SX1272",
             "lora-spi-mosi":        "LORA_MOSI",
             "lora-spi-miso":        "LORA_MISO",
@@ -138,8 +128,6 @@
         },
 
         "MTB_MTS_XDOT": {
-            "lorawan-enabled":      true,
-
             "lora-radio":           "SX1272",
             "lora-spi-mosi":        "LORA_MOSI",
             "lora-spi-miso":        "LORA_MISO",
@@ -162,8 +150,6 @@
         },
 
         "LTEK_FF1705": {
-            "lorawan-enabled":      true,
-
             "lora-radio":           "SX1272",
             "lora-spi-mosi":        "LORA_MOSI",
             "lora-spi-miso":        "LORA_MISO",
@@ -186,8 +172,6 @@
         },
 
         "MTS_MDOT_F411RE": {
-            "lorawan-enabled":      true,
-
             "lora-radio":           "SX1272",
             "lora-spi-mosi":        "LORA_MOSI",
             "lora-spi-miso":        "LORA_MISO",
@@ -210,8 +194,6 @@
         },
 
         "MTB_ADV_WISE_1510": {
-            "lorawan-enabled":      true,
-
             "lora-radio":           "SX1276",
             "lora-spi-mosi":        "SPI_RF_MOSI",
             "lora-spi-miso":        "SPI_RF_MISO",
@@ -234,8 +216,6 @@
         },
 
         "MTB_RAK811": {
-            "lorawan-enabled":     true,
-
             "lora-radio":          "SX1276",
             "lora-spi-mosi":       "SPI_RF_MOSI",
             "lora-spi-miso":       "SPI_RF_MISO",


### PR DESCRIPTION
mbed-os-example-lorawan project is now CI tested only for targets which really have lora HW (mbed-os commit b61912cbbed16cf5262ec88376738aec65413741). Therefore DEVICE_SPI and MBED_CONF_APP_LORAWAN_ENABLED are no longer needed.

This fixes issues #62 and #63.