### PR TITLE
Disable some ciphers not needed by lora example application

### DIFF
--- a/mbedtls_lora_config.h
+++ b/mbedtls_lora_config.h
@@ -34,7 +34,10 @@
 // These are only reference configurations for this LoRa example application.
 // Other LoRa applications might need different configurations.
 #define MBEDTLS_AES_FEWER_TABLES
-#undef MBEDTLS_GCM_C
 
+#undef MBEDTLS_GCM_C
+#undef MBEDTLS_CHACHA20_C
+#undef MBEDTLS_CHACHAPOLY_C
+#undef MBEDTLS_POLY1305_C
 
 #endif /* MBEDTLS_LORA_CONFIG_H */


### PR DESCRIPTION
These ciphers are not needed by this example application and these
consume about 2500 bytes of ROM.

https://github.com/ARMmbed/mbed-os/issues/7994
