### PR TITLE
Enabled ARMC6 compiler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,8 +40,8 @@ def targets = [
 def toolchains = [
   ARM: "armcc",
   GCC_ARM: "arm-none-eabi-gcc",
-  IAR: "iar_arm"
-  //ARMC6: "arm6"
+  IAR: "iar_arm",
+  ARMC6: "arm6"
 ]
 
 def stepsForParallel = [:]


### PR DESCRIPTION
Legacy alignment has been restored in mbed-os, therefore we can enable ARMC6 compiler again.