### PR TITLE
Should send unconfirmed by default

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -168,7 +168,7 @@ static void send_message()
                          sensor_value);
 
     retcode = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_buffer, packet_len,
-                           MSG_CONFIRMED_FLAG);
+                           MSG_UNCONFIRMED_FLAG);
 
     if (retcode < 0) {
         retcode == LORAWAN_STATUS_WOULD_BLOCK ? printf("send - WOULD BLOCK\r\n")


### PR DESCRIPTION
We're being a bad citizen for networks right now. We send as fast as possible and send messages confirmed. Our official example should show the right way of building LoRaWAN devices.

@hasnainvirk @AnttiKauppila 