### PR TITLE
Retry if mbed deploy fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,12 +88,12 @@ def buildStep(target, toolchain) {
           checkout scm
 
           // A few retries due to mbed-cli caching issues
-          retry(3) {
-            try {
+          try {
+            retry(3) {
               execute("mbed deploy --protocol ssh")
-            } catch (err) {
-                echo "mbed deploy failed"
             }
+          } catch (err) {
+              echo "mbed deploy failed"
           }
 
           // Set mbed-os to revision received as parameter
@@ -152,12 +152,13 @@ def build_regions(regions) {
         dir("mbed-os-example-lorawan") {
           checkout scm
 
-          retry(3) {
-            try {
+          // A few retries due to mbed-cli caching issues
+          try {
+            retry(3) {
               execute("mbed deploy --protocol ssh")
-            } catch (err) {
-                echo "mbed deploy failed"
             }
+          } catch (err) {
+              echo "mbed deploy failed"
           }
 
           if (env.MBED_OS_REVISION != '') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,13 +87,13 @@ def buildStep(target, toolchain) {
         dir("mbed-os-example-lorawan") {
           checkout scm
 
-          // A few retries due to mbed-cli caching issues
+          // A workaround for mbed-cli caching issues
           try {
-            retry(3) {
-              execute("mbed deploy --protocol ssh")
-            }
+            execute("mbed deploy --protocol ssh")
           } catch (err) {
-              echo "mbed deploy failed"
+              echo "mbed deploy failed - retrying after 10s"
+              sleep(10)
+              execute("mbed deploy --protocol ssh")
           }
 
           // Set mbed-os to revision received as parameter
@@ -152,13 +152,13 @@ def build_regions(regions) {
         dir("mbed-os-example-lorawan") {
           checkout scm
 
-          // A few retries due to mbed-cli caching issues
+          // A workaround for mbed-cli caching issues
           try {
-            retry(3) {
-              execute("mbed deploy --protocol ssh")
-            }
+            execute("mbed deploy --protocol ssh")
           } catch (err) {
-              echo "mbed deploy failed"
+              echo "mbed deploy failed - retrying after 10s"
+              sleep(10)
+              execute("mbed deploy --protocol ssh")
           }
 
           if (env.MBED_OS_REVISION != '') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,15 @@ def buildStep(target, toolchain) {
         deleteDir()
         dir("mbed-os-example-lorawan") {
           checkout scm
-          execute("mbed deploy --protocol ssh")
+
+          // A few retries due to mbed-cli caching issues
+          retry(3) {
+            try {
+              execute("mbed deploy --protocol ssh")
+            } catch (err) {
+                echo "mbed deploy failed"
+            }
+          }
 
           // Set mbed-os to revision received as parameter
           if (env.MBED_OS_REVISION != '') {
@@ -143,7 +151,14 @@ def build_regions(regions) {
         deleteDir()
         dir("mbed-os-example-lorawan") {
           checkout scm
-          execute("mbed deploy --protocol ssh")
+
+          retry(3) {
+            try {
+              execute("mbed deploy --protocol ssh")
+            } catch (err) {
+                echo "mbed deploy failed"
+            }
+          }
 
           if (env.MBED_OS_REVISION != '') {
             dir("mbed-os") {


### PR DESCRIPTION
About 5% of our builds are failing due to mbed-cli caching issue (ERROR: File exists). This is a workaround until it is fixed.