### PR TITLE
Add support for the Embedded Planet Agora target

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Here is a nonexhaustive list of boards and modules that we have tested with the 
 Here is a list of boards and modules that have been tested by the community:
 
 - IMST iM880B (SX1272)
+- Embedded Planet Agora (SX1276)
 
 ## Compiling the application
 

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0063e5de32fc575f061244c96ac60c41c07bd2e6
+https://github.com/ARMmbed/mbed-os/#b6e5a0a8afa34dec9dae8963778aebce0c82a54b

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -258,6 +258,28 @@
             "lora-ant-switch":     "NC",
             "lora-pwr-amp-ctl":    "NC",
             "lora-tcxo":           "NC"
+        },
+
+        "EP_AGORA": {
+            "target.macros_add":   ["NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS=4"],
+            "lora-spi-mosi":       "PIN_NAME_LORA_MOSI",
+            "lora-spi-miso":       "PIN_NAME_LORA_MISO",
+            "lora-spi-sclk":       "PIN_NAME_LORA_SCLK",
+            "lora-cs":             "PIN_NAME_LORA_SSN",
+            "lora-reset":          "PIN_NAME_LORA_RESETN",
+            "lora-dio0":           "PIN_NAME_LORA_DIO0",
+            "lora-dio1":           "PIN_NAME_LORA_DIO1",
+            "lora-dio2":           "PIN_NAME_LORA_DIO2",
+            "lora-dio3":           "PIN_NAME_LORA_DIO3",
+            "lora-dio4":           "NC",
+            "lora-dio5":           "NC",
+            "lora-rf-switch-ctl1": "NC",
+            "lora-rf-switch-ctl2": "NC",
+            "lora-txctl":          "NC",
+            "lora-rxctl":          "NC",
+            "lora-ant-switch":     "NC",
+            "lora-pwr-amp-ctl":    "NC",
+            "lora-tcxo":           "NC"
         }
     },
     "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_lora_config.h\""]


### PR DESCRIPTION
This PR adds support for the Embedded Planet Agora target (`EP_AGORA`), and also updates the example to use mbed-os 5.14.0.