### PR TITLE
Jenkinsfile: disable IAR build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,8 +39,7 @@ def targets = [
 // Supported toolchains
 def toolchains = [
   "ARM",
-  "GCC_ARM",
-  "IAR"
+  "GCC_ARM"
 ]
 
 def stepsForParallel = [:]


### PR DESCRIPTION
Jenkinsfile: disable IAR build
- IAR build disabled due to license issue
