### PR TITLE
adding two example config files for:

### DIFF
--- a/config/P-NUCLEO-LRWAN1_example_config.json
+++ b/config/P-NUCLEO-LRWAN1_example_config.json
@@ -1,0 +1,67 @@
+{
+    "config": {
+        "lora-radio": {
+            "help": "Which radio to use (options: SX126X, SX1272, SX1276) -- See config/ dir for example configs",
+            "value": "SX1276"
+        },
+        "main_stack_size":     { "value": 4096 },
+
+        "lora-spi-mosi":       { "value": "NC" },
+        "lora-spi-miso":       { "value": "NC" },
+        "lora-spi-sclk":       { "value": "NC" },
+        "lora-cs":             { "value": "NC" },
+        "lora-reset":          { "value": "NC" },
+        "lora-dio0":           { "value": "NC" },
+        "lora-dio1":           { "value": "NC" },
+        "lora-dio2":           { "value": "NC" },
+        "lora-dio3":           { "value": "NC" },
+        "lora-dio4":           { "value": "NC" },
+        "lora-dio5":           { "value": "NC" },
+        "lora-rf-switch-ctl1": { "value": "NC" },
+        "lora-rf-switch-ctl2": { "value": "NC" },
+        "lora-txctl":          { "value": "NC" },
+        "lora-rxctl":          { "value": "NC" },
+        "lora-ant-switch":     { "value": "NC" },
+        "lora-pwr-amp-ctl":    { "value": "NC" },
+        "lora-tcxo":           { "value": "NC" }
+    },
+    "target_overrides": {
+        "*": {
+            "platform.stdio-convert-newlines": true,
+            "platform.stdio-baud-rate": 115200,
+            "platform.default-serial-baud-rate": 115200,
+            "lora.over-the-air-activation": true,
+            "lora.duty-cycle-on": false,
+            "lora.phy": "EU868",
+            "lora.device-eui":      "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
+            "lora.application-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
+            "lora.application-key": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }"
+        },
+
+        "NUCLEO_L073RZ": {
+            "main_stack_size":      1024,
+            "lora-radio":          "SX1272",
+            "lora-spi-mosi":       "D11",
+            "lora-spi-miso":       "D12",
+            "lora-spi-sclk":       "D13",
+            "lora-cs":             "D10",
+            "lora-reset":          "A0",
+            "lora-dio0":           "D2",
+            "lora-dio1":           "D3",
+            "lora-dio2":           "D4",
+            "lora-dio3":           "D5",
+            "lora-dio4":           "NC",
+            "lora-dio5":           "NC",
+            "lora-rf-switch-ctl1": "NC",
+            "lora-rf-switch-ctl2": "NC",
+            "lora-txctl":          "NC",
+            "lora-rxctl":          "NC",
+            "lora-ant-switch":     "NC",
+            "lora-pwr-amp-ctl":    "NC",
+            "lora-tcxo":           "NC"
+        }
+
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_lora_config.h\""]
+}
+

--- a/config/SX1276MB1xAS_example_config.json
+++ b/config/SX1276MB1xAS_example_config.json
@@ -1,0 +1,67 @@
+{
+    "config": {
+        "lora-radio": {
+            "help": "Which radio to use (options: SX126X, SX1272, SX1276) -- See config/ dir for example configs",
+            "value": "SX1276"
+        },
+        "main_stack_size":     { "value": 4096 },
+
+        "lora-spi-mosi":       { "value": "NC" },
+        "lora-spi-miso":       { "value": "NC" },
+        "lora-spi-sclk":       { "value": "NC" },
+        "lora-cs":             { "value": "NC" },
+        "lora-reset":          { "value": "NC" },
+        "lora-dio0":           { "value": "NC" },
+        "lora-dio1":           { "value": "NC" },
+        "lora-dio2":           { "value": "NC" },
+        "lora-dio3":           { "value": "NC" },
+        "lora-dio4":           { "value": "NC" },
+        "lora-dio5":           { "value": "NC" },
+        "lora-rf-switch-ctl1": { "value": "NC" },
+        "lora-rf-switch-ctl2": { "value": "NC" },
+        "lora-txctl":          { "value": "NC" },
+        "lora-rxctl":          { "value": "NC" },
+        "lora-ant-switch":     { "value": "NC" },
+        "lora-pwr-amp-ctl":    { "value": "NC" },
+        "lora-tcxo":           { "value": "NC" }
+    },
+    "target_overrides": {
+        "*": {
+            "platform.stdio-convert-newlines": true,
+            "platform.stdio-baud-rate": 115200,
+            "platform.default-serial-baud-rate": 115200,
+            "lora.over-the-air-activation": true,
+            "lora.duty-cycle-on": false,
+            "lora.phy": "EU868",
+            "lora.device-eui":      "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
+            "lora.application-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
+            "lora.application-key": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }"
+        },
+
+        "NUCLEO_L073RZ": {
+            "main_stack_size":      1024,
+            "lora-radio":          "SX1276",
+            "lora-spi-mosi":       "D11",
+            "lora-spi-miso":       "D12",
+            "lora-spi-sclk":       "D13",
+            "lora-cs":             "D10",
+            "lora-reset":          "A0",
+            "lora-dio0":           "D2",
+            "lora-dio1":           "D3",
+            "lora-dio2":           "D4",
+            "lora-dio3":           "D5",
+            "lora-dio4":           "D8",
+            "lora-dio5":           "D9",
+            "lora-rf-switch-ctl1": "NC",
+            "lora-rf-switch-ctl2": "NC",
+            "lora-txctl":          "NC",
+            "lora-rxctl":          "NC",
+            "lora-ant-switch":     "A4",
+            "lora-pwr-amp-ctl":    "NC",
+            "lora-tcxo":           "NC"
+        }
+
+    },
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"mbedtls_lora_config.h\""]
+}
+


### PR DESCRIPTION
- SX1272MB2xAS part of P-NUCLEO-LRWAN1 - https://os.mbed.com/components/SX1272MB2xAS/
- SX1276MB1xAS - https://os.mbed.com/components/SX1276MB1xAS/

Both example configs are tested together with NUCLEO_L073RZ, which is part of the P-NUCLEO-LRWAN1 package, Mbed OS 5.14.2 and uVision 5.28.
P-NUCLEO-LRWAN2 was used as a gateway to TTN.