### PR TITLE
Use lora drivers from mbed-os repository

### DIFF
--- a/config/SX126X_example_config.json
+++ b/config/SX126X_example_config.json
@@ -26,6 +26,7 @@
             "platform.default-serial-baud-rate": 115200,
             "lora.over-the-air-activation": true,
             "lora.duty-cycle-on": true,
+            "target.components_add": ["SX126X"],
             "lora.phy": "EU868",
             "lora.device-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
             "lora.application-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",

--- a/config/SX127X_example_config.json
+++ b/config/SX127X_example_config.json
@@ -32,6 +32,7 @@
             "platform.default-serial-baud-rate": 115200,
             "lora.over-the-air-activation": true,
             "lora.duty-cycle-on": true,
+            "target.components_add": ["SX1272", "SX1276"],
             "lora.phy": "EU868",
             "lora.device-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
             "lora.application-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",

--- a/mbed-lora-radio-drv.lib
+++ b/mbed-lora-radio-drv.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-semtech-lora-rf-drivers#0f7efe3ad17c6c619843b8391b3035149f358260

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -32,6 +32,7 @@
             "platform.default-serial-baud-rate": 115200,
             "lora.over-the-air-activation": true,
             "lora.duty-cycle-on": true,
+            "target.components_add": ["SX1272", "SX1276", "SX126X"],
             "lora.phy": "EU868",
             "lora.device-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",
             "lora.application-eui": "{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }",


### PR DESCRIPTION
Lora drivers are now (since mbed-os 6.0) included in mbed-os so separate driver repository is no longer needed.