### PR TITLE
CMake: Use renamed Mbed CMake targets component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ mbed_set_mbed_target_linker_script(${APP_TARGET})
 project(${APP_TARGET})
 
 # Provide Mbed OS with the header file it needs to configure Mbed TLS for LoRa
-target_include_directories(mbed-os
+target_include_directories(${APP_TARGET}
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
@@ -31,9 +31,10 @@ target_sources(${APP_TARGET}
 )
 
 target_link_libraries(${APP_TARGET}
-    mbed-os
-    mbed-os-lorawan
-    mbed-os-mbedtls
+    PRIVATE
+        mbed-os
+        mbed-lorawan
+        mbed-mbedtls
 )
 
 mbed_generate_bin_hex(${APP_TARGET})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET mbed-os-example-lorawan)
 
+include(${MBED_ROOT}/tools/cmake/app.cmake)
+
 add_subdirectory(${MBED_ROOT})
 
 add_executable(${APP_TARGET})


### PR DESCRIPTION
They are now prefixed with "mbed-" instead of "mbed-os-"