### PR TITLE
CMake: Remove unnecessary library addition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os
         mbed-lorawan
-        mbed-mbedtls
 )
 
 mbed_set_post_build(${APP_TARGET})


### PR DESCRIPTION
The dependency on TLS is now handled by Mbed OS

Depends on https://github.com/ARMmbed/mbed-os/pull/14098