### PR TITLE
STM32WL : NUCLEO_WL55JC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ This is an example application based on `Mbed-OS` LoRaWAN protocol APIs. The Mbe
 
 OR
 
+Mbed Enabled LoRa MCU:
+- STM32WL : [NUCLEO_WL55JC](https://os.mbed.com/platforms/ST-Nucleo-WL55JC/)
+
+OR
+
 [Mbed Enabled LoRa Module](#module-support)
 
 ### Import the example application
@@ -112,11 +117,13 @@ Here is a nonexhaustive list of boards and modules that we have tested with the 
 - LTEK_FF1705 (SX1272)
 - Advantech Wise 1510 (SX1276)
 - ST B-L072Z-LRWAN1 LoRa®Discovery kit with Murata CMWX1ZZABZ-091 module (SX1276)
+- ST NUCLEO-WL55JC with sub-GHz SoC (STM32WL)
 
 Here is a list of boards and modules that have been tested by the community:
 
 - IMST iM880B (SX1272)
 - Embedded Planet Agora (SX1276)
+
 
 ## Compiling the application
 

--- a/lora_radio_helper.h
+++ b/lora_radio_helper.h
@@ -76,8 +76,13 @@ SX126X_LoRaRadio radio(MBED_CONF_SX126X_LORA_DRIVER_SPI_MOSI,
                        MBED_CONF_SX126X_LORA_DRIVER_XTAL_SEL,
                        MBED_CONF_SX126X_LORA_DRIVER_ANT_SWITCH);
 
+#elif (TARGET_STM32WL)
+#include "STM32WL_LoRaRadio.h"
+STM32WL_LoRaRadio radio(MBED_CONF_STM32WL_LORA_DRIVER_RF_SWITCH_CTL1,
+                        MBED_CONF_STM32WL_LORA_DRIVER_RF_SWITCH_CTL2,
+                        MBED_CONF_STM32WL_LORA_DRIVER_RF_SWITCH_CTL3);
 #else
-#error "Unknown LoRa radio specified (SX126X, SX1272, SX1276 are valid)"
+#error "Unknown LoRa radio specified (SX126X, SX1272, SX1276, STM32WL are valid)"
 #endif
 
 #endif /* APP_LORA_RADIO_HELPER_H_ */

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -35,6 +35,11 @@
             "main_stack_size":      1024
         },
 
+        "NUCLEO_WL55JC": {
+            "stm32wl-lora-driver.debug_rx": "LED1",
+            "stm32wl-lora-driver.debug_tx": "LED2"
+        },
+
         "MTB_MURATA_ABZ": {
             "main_stack_size":      1024,
             "target.components_add":            ["SX1276"],


### PR DESCRIPTION
Hi

After https://github.com/ARMmbed/mbed-os/pull/14249
merge in mbed-os

NUCLEO_WL55JC is now LoRa capable by default.

Thx

@ludoch-stm
@ARMmbed/team-st-mcd
@MarceloSalazar 
