### PR TITLE
Minor patches for example easy usage

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -7,6 +7,8 @@
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200,
             "platform.default-serial-baud-rate": 115200,
+            "mbed-trace.enable": false,
+            "mbed-trace.max-level": "TRACE_LEVEL_DEBUG",
             "lora.over-the-air-activation": true,
             "lora.duty-cycle-on": true,
             "lora.phy": "EU868",


### PR DESCRIPTION
2 minor patches:
- .mbed file should not in git files
- mbed-trace option is added in mbbed_app.json : no impact as default value is false, but helps customer to enable it