### PR TITLE
Update for mbed-os-6.12.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#14e5d307bb6cdccb554b591ab2602d8d47e0b2d0
+https://github.com/ARMmbed/mbed-os/#cecc47b4a53951527dd3f670465c8566396ad101

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -7,6 +7,8 @@
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200,
             "platform.default-serial-baud-rate": 115200,
+            "mbed-trace.enable": false,
+            "mbed-trace.max-level": "TRACE_LEVEL_DEBUG",
             "lora.over-the-air-activation": true,
             "lora.duty-cycle-on": true,
             "lora.phy": "EU868",


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.12.0 release of mbed-os. 