### PR TITLE
Update for mbed-os-6.13.0

### DIFF
--- a/lora_radio_helper.h
+++ b/lora_radio_helper.h
@@ -78,9 +78,7 @@ SX126X_LoRaRadio radio(MBED_CONF_SX126X_LORA_DRIVER_SPI_MOSI,
 
 #elif (TARGET_STM32WL)
 #include "STM32WL_LoRaRadio.h"
-STM32WL_LoRaRadio radio(MBED_CONF_STM32WL_LORA_DRIVER_RF_SWITCH_CTL1,
-                        MBED_CONF_STM32WL_LORA_DRIVER_RF_SWITCH_CTL2,
-                        MBED_CONF_STM32WL_LORA_DRIVER_RF_SWITCH_CTL3);
+STM32WL_LoRaRadio radio;
 #else
 #error "Unknown LoRa radio specified (SX126X, SX1272, SX1276, STM32WL are valid)"
 #endif

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#cecc47b4a53951527dd3f670465c8566396ad101
+https://github.com/ARMmbed/mbed-os/#d147abc3e556c58e5e343d34b729bc2192e18bd3


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.13.0 release of mbed-os. 